### PR TITLE
Fix Fisher-Yates shuffler

### DIFF
--- a/packages/server/src/game/core/arbiter.ts
+++ b/packages/server/src/game/core/arbiter.ts
@@ -43,7 +43,7 @@ export class Arbiter {
     }
 
     for (let i = len-1; i > 0; i--) {
-      const position = Math.floor(Math.random() * i);
+      const position = Math.floor(Math.random() * (i+1));
       [order[i], order[position]] = [order[position], order[i]];
     }
 

--- a/packages/server/src/game/core/arbiter.ts
+++ b/packages/server/src/game/core/arbiter.ts
@@ -42,11 +42,9 @@ export class Arbiter {
       order.push(i);
     }
 
-    for (let i = 0; i < len; i++) {
-      const position = Math.min(len - 1, Math.round(Math.random() * len));
-      const tmp = order[i];
-      order[i] = order[position];
-      order[position] = tmp;
+    for (let i = len-1; i > 0; i--) {
+      const position = Math.floor(Math.random() * i);
+      [order[i], order[position]] = [order[position], order[i]];
     }
 
     return order;


### PR DESCRIPTION
The method used by the arbiter for shuffling decks has some flaws, and won't produce a uniform distribution. Compare it to the example of an incorrect shuffler described in the "Naive method" section at https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Na%C3%AFve_method

I've replaced the implementation with one that more accurately implements the Fisher-Yates shuffle.