### PR TITLE
Create library of common behaviors for easier implementing of card effects

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -7,3 +7,4 @@ export * from './utils';
 export * from './api-error';
 export * from './game-error';
 export * from './game-message';
+export * from './test-utils';

--- a/packages/common/src/store/card/trainer-card.ts
+++ b/packages/common/src/store/card/trainer-card.ts
@@ -1,3 +1,5 @@
+import { Resolver } from '../resolve-effect';
+import { State } from '../state/state';
 import { Card } from './card';
 import { SuperType, TrainerType } from './card-types';
 
@@ -9,4 +11,6 @@ export abstract class TrainerCard extends Card {
   public trainerType: TrainerType = TrainerType.ITEM;
 
   public text: string = '';
+
+  public *onPlay(resolver: Resolver): Generator<State> {}
 }

--- a/packages/common/src/store/effect-reducers/play-trainer-effect.ts
+++ b/packages/common/src/store/effect-reducers/play-trainer-effect.ts
@@ -6,8 +6,6 @@ import { Effect } from '../effects/effect';
 import { State } from '../state/state';
 import { StoreLike } from '../store-like';
 import { StateUtils } from '../state-utils';
-import { TrainerType } from '../card/card-types';
-
 
 export function playTrainerReducer(store: StoreLike, state: State, effect: Effect): State {
 
@@ -73,16 +71,6 @@ export function playTrainerReducer(store: StoreLike, state: State, effect: Effec
       name: effect.player.name,
       card: effect.trainerCard.name
     });
-    return state;
-  }
-
-  // Process trainer effect
-  if (effect instanceof TrainerEffect) {
-    if (effect.player.hand.cards.includes(effect.trainerCard)) {
-      const isSupporter = effect.trainerCard.trainerType === TrainerType.SUPPORTER;
-      const target = isSupporter ? effect.player.supporter : effect.player.discard;
-      effect.player.hand.moveCardTo(effect.trainerCard, target);
-    }
     return state;
   }
 

--- a/packages/common/src/store/index.ts
+++ b/packages/common/src/store/index.ts
@@ -50,8 +50,10 @@ export * from './state/rules';
 export * from './state/state-log';
 export * from './state/state';
 
+export * from './resolve-effect';
 export * from './requirement';
 export * from './state-utils';
 export * from './store-handler';
 export * from './store-like';
 export * from './store';
+export * from './target-utils';

--- a/packages/common/src/store/index.ts
+++ b/packages/common/src/store/index.ts
@@ -50,6 +50,7 @@ export * from './state/rules';
 export * from './state/state-log';
 export * from './state/state';
 
+export * from './requirement';
 export * from './state-utils';
 export * from './store-handler';
 export * from './store-like';

--- a/packages/common/src/store/prompts/choose-cards-prompt.ts
+++ b/packages/common/src/store/prompts/choose-cards-prompt.ts
@@ -5,7 +5,8 @@ import { GameMessage } from '../../game-message';
 import { Prompt } from './prompt';
 import { PokemonCard } from '../card/pokemon-card';
 import { TrainerCard } from '../card/trainer-card';
-import { CardType, SuperType } from '../card/card-types';
+import { CardType, EnergyType, Stage, SuperType, TrainerType } from '../card/card-types';
+import { Filter } from '../../utils';
 
 export const ChooseCardsPromptType = 'Choose cards';
 
@@ -21,7 +22,7 @@ export interface ChooseCardsOptions {
   maxTrainers: number | undefined;
 }
 
-export type FilterType = Partial<PokemonCard | TrainerCard | EnergyCard>;
+export type FilterType = Filter<PokemonCard | TrainerCard | EnergyCard>;
 
 export class ChooseCardsPrompt extends Prompt<Card[]> {
 
@@ -123,5 +124,17 @@ export class ChooseCardsPrompt extends Prompt<Card[]> {
     }
     return true;
   }
-
 }
+
+export const FilterType: Record<any, FilterType> = {
+  ENERGY : { superType: SuperType.ENERGY },
+  BASIC_ENERGY: { superType: SuperType.ENERGY, energyType: EnergyType.BASIC },
+  SPECIAL_ENERGY: { superType: SuperType.ENERGY, energyType: EnergyType.SPECIAL },
+  POKEMON: { superType: SuperType.POKEMON },
+  BASIC_POKEMON: { superType: SuperType.POKEMON, stage: Stage.BASIC },
+  TRAINER: { superType: SuperType.TRAINER },
+  ITEM: { superType: SuperType.TRAINER, trainerType: TrainerType.ITEM },
+  SUPPORTER: { superType: SuperType.TRAINER, trainerType: TrainerType.SUPPORTER },
+  STADIUM: { superType: SuperType.TRAINER, trainerType: TrainerType.STADIUM },
+  TOOL: { superType: SuperType.TRAINER, trainerType: TrainerType.TOOL },
+};

--- a/packages/common/src/store/requirement.ts
+++ b/packages/common/src/store/requirement.ts
@@ -11,13 +11,13 @@ export class Require {
   public readonly activePlayer: Player;
   public readonly state: State;
   public readonly effectSource?: Card;
-  public readonly fail: (message: string) => void;
+  public readonly fail: (message?: string) => void;
 
   constructor({activePlayer, state, effectSource, fail}: {
     activePlayer: Player,
     state: State,
     effectSource?: Card,
-    fail: (message: string) => void,
+    fail: (message?: string) => void,
   }) {
     this.activePlayer = activePlayer;
     this.state = state;
@@ -33,7 +33,7 @@ export class Require {
     return new RequirePlayer(this, StateUtils.getOpponent(this.state, this.activePlayer), 'opponent');
   }
 
-  public check(condition: boolean, message: string) {
+  public check(condition: boolean, message?: string) {
     if(!condition) {
       this.fail(message);
     }

--- a/packages/common/src/store/requirement.ts
+++ b/packages/common/src/store/requirement.ts
@@ -3,8 +3,9 @@ import { CardList } from './state/card-list';
 import { Player } from './state/player';
 import { StateUtils } from './state-utils';
 import { State } from './state/state';
-import { match } from '../utils/utils';
+import { Filter, match } from '../utils/utils';
 import { PokemonCard } from './card/pokemon-card';
+import { FilterType } from './prompts/choose-cards-prompt';
 
 export class Require {
 
@@ -80,9 +81,9 @@ class RequireZone {
   }
 
   public contains(cards: Card[]): void;
-  public contains(count: number, like?: Partial<Card>): void;
-  public contains({atLeast, atMost, like}: {atLeast?: number, atMost?: number, like?: Partial<Card>}): void;
-  public contains(arg0: Card[] | number | {atLeast?: number, atMost?: number, like?: Partial<Card>}, like?: Partial<Card>): void {
+  public contains(count: number, like?: FilterType): void;
+  public contains({atLeast, atMost, like}: {atLeast?: number, atMost?: number, like?: FilterType}): void;
+  public contains(arg0: Card[] | number | {atLeast?: number, atMost?: number, like?: FilterType}, like?: FilterType): void {
     if (typeof arg0 === 'number') {
       const atLeast = arg0;
       const atMost = arg0;
@@ -129,8 +130,8 @@ class RequirePlayer {
   public hasPokemon({ atLeast, atMost, like = {}, with: with_ = {}}: {
     atLeast?: number,
     atMost?: number,
-    like?: Partial<PokemonCard>
-    with?: Partial<Card>
+    like?: Filter<PokemonCard>
+    with?: FilterType
   }) {
     const slots = [this.player.active, ...this.player.bench];
     const matchedSlots = slots.filter(

--- a/packages/common/src/store/requirement.ts
+++ b/packages/common/src/store/requirement.ts
@@ -1,0 +1,148 @@
+import { Card } from './card/card';
+import { CardList } from './state/card-list';
+import { Player } from './state/player';
+import { StateUtils } from './state-utils';
+import { State } from './state/state';
+import { match } from '../utils/utils';
+import { PokemonCard } from './card/pokemon-card';
+
+export class Require {
+
+  public readonly activePlayer: Player;
+  public readonly state: State;
+  public readonly effectSource?: Card;
+  public readonly fail: (message: string) => void;
+
+  constructor({activePlayer, state, effectSource, fail}: {
+    activePlayer: Player,
+    state: State,
+    effectSource?: Card,
+    fail: (message: string) => void,
+  }) {
+    this.activePlayer = activePlayer;
+    this.state = state;
+    this.effectSource = effectSource;
+    this.fail = fail;
+  }
+
+  get player() {
+    return new RequirePlayer(this, this.activePlayer, 'player');
+  }
+
+  get opponent() {
+    return new RequirePlayer(this, StateUtils.getOpponent(this.state, this.activePlayer), 'opponent');
+  }
+
+  public check(condition: boolean, message: string) {
+    if(!condition) {
+      this.fail(message);
+    }
+  }
+
+  public noPrompts() {
+    const prompts = this.state.prompts;
+    const prompt = prompts.find(p => p.result === undefined);
+    this.check(prompt === undefined, `Expected no unresolved prompts but found: ${prompt?.type}`);
+  }
+}
+
+class RequireZone {
+  constructor(
+    private readonly require: Require,
+    public readonly zone: CardList,
+    private name: string,
+  ) {}
+
+  public isNotEmpty() {
+    this.require.check(this.zone.cards.length > 0, `${this.name} unexpectedly empty.`);
+  }
+
+  public isEmpty() {
+    this.require.check(this.zone.cards.length === 0, `${this.name} unexpectedly not empty.`);
+  }
+
+  public doesNotContain(card: Card): void {
+    if (this.zone.cards.includes(card)) {
+      this.require.fail(`${this.name} unexpectedly contains card: ${card.name}`);
+    }
+  }
+
+  public isInOrder(order: Card[]): void {
+    if (this.zone.cards.length !== order.length) {
+      this.require.fail(`${this.name} has a different number of cards than expected. Expected ${order.length}, found ${this.zone.cards.length}.`);
+    }
+    for (let i = 0; i < order.length; i++) {
+      const card = order[i];
+      if (this.zone.cards[i] !== card) {
+        this.require.fail(`${this.name} has card ${this.zone.cards[i].name} at position ${i}, expected ${card.name}.`);
+      }
+    }
+  }
+
+  public contains(cards: Card[]): void;
+  public contains(count: number, like?: Partial<Card>): void;
+  public contains({atLeast, atMost, like}: {atLeast?: number, atMost?: number, like?: Partial<Card>}): void;
+  public contains(arg0: Card[] | number | {atLeast?: number, atMost?: number, like?: Partial<Card>}, like?: Partial<Card>): void {
+    if (typeof arg0 === 'number') {
+      const atLeast = arg0;
+      const atMost = arg0;
+      return this.contains({ atLeast, atMost, like });
+    }
+    if (Array.isArray(arg0)) {
+      const cards = arg0;
+      if (!this.zone.cards.every(val => cards.includes(val))) {
+        this.require.fail(`${this.name} does not contain all required cards: ${cards.map(card => card.name).join(', ')}`);
+      }
+      return;
+    }
+    const { atLeast, atMost } = arg0;
+    const cards = like ? this.zone.filter(like) : this.zone.cards;
+    const matches = cards.filter(card => card != this.require.effectSource);
+    if (atLeast !== undefined && matches.length < atLeast) {
+      this.require.fail(`${this.name} does not contain enough cards matching the criteria. Expected at least ${atLeast}, found ${matches.length}.`);
+    }
+    if (atMost !== undefined && matches.length > atMost) {
+      this.require.fail(`${this.name} contains too many cards matching the criteria. Expected at most ${atMost}, found ${matches.length}.`);
+    }
+    if (atLeast === undefined && atMost === undefined && matches.length === 0) {
+      this.require.fail(`${this.name} does not contain any cards matching the criteria.`);
+    }
+  }
+}
+class RequirePlayer {
+  constructor(
+    public readonly require: Require,
+    public readonly player: Player,
+    private name: string,
+  ) {}
+
+  public readonly hand = new RequireZone(this.require, this.player.hand, `${this.name}'s hand`);
+
+  public readonly deck = new RequireZone(this.require, this.player.deck, `${this.name}'s deck`);
+
+  public readonly discard = new RequireZone(this.require, this.player.discard, `${this.name}'s discard pile`);
+
+  public readonly supporter = new RequireZone(this.require, this.player.supporter, `${this.name}'s supporter zone`);
+
+  public readonly activeSpot = new RequireZone(this.require, this.player.active, `${this.name}'s active spot`); 
+
+  public hasPokemon({ atLeast, atMost, like = {}, with: with_ = {}}: {
+    atLeast?: number,
+    atMost?: number,
+    like?: Partial<PokemonCard>
+    with?: Partial<Card>
+  }) {
+    const slots = [this.player.active, ...this.player.bench];
+    const matchedSlots = slots.filter(
+      pokemon => match(pokemon.getPokemonCard()!, like) && pokemon.cards.some(card => match(card, with_)));
+    if (atLeast !== undefined && matchedSlots.length < atLeast) {
+      this.require.fail(`${this.name} does not have enough Pokémon matching the criteria. Expected at least ${atLeast}, found ${matchedSlots.length}.`);
+    }
+    if (atMost !== undefined && matchedSlots.length > atMost) {
+      this.require.fail(`${this.name} has too many Pokémon matching the criteria. Expected at most ${atMost}, found ${matchedSlots.length}.`);
+    }
+    if (atLeast === undefined && atMost === undefined && matchedSlots.length === 0) {
+      this.require.fail(`${this.name} does not have any Pokémon matching the criteria.`);
+    }
+  }
+}

--- a/packages/common/src/store/resolve-effect.ts
+++ b/packages/common/src/store/resolve-effect.ts
@@ -95,9 +95,7 @@ export class Resolver {
     return new ResolveForPlayer(this, StateUtils.getOpponent(this.state, this.effect.player));
   }
 
-  public *choosesAndMoves(player: Player, from: CardList, to: CardList, message: GameMessage, query?: FilterType, args?: Partial<ChooseCardsOptions>): Generator<State, State> {
-    query = query || {};
-    const choices = from.filter(query).filter(card => !this.excluded.includes(card));
+  public *choosesAndMoves(player: Player, from: CardList, to: CardList, message: GameMessage, query: FilterType = {}, args?: Partial<ChooseCardsOptions>): Generator<State, State> {
     const min = args?.min || 1;
     if (choices.length < min) {
       throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
@@ -152,18 +150,18 @@ class ResolveForPlayer {
     return this.resolver.state;
   }
 
-  public discards(count: number, like?: Partial<Card>): ResolveMoveToZone;
+  public discards(count: number, like?: FilterType): ResolveMoveToZone;
   public discards({atLeast, atMost, like} : SelectCardArgs): ResolveMoveToZone;
-  public discards(countOrArgs: number | SelectCardArgs, like?: Partial<Card>): ResolveMoveToZone {
+  public discards(countOrArgs: number | SelectCardArgs, like?: FilterType): ResolveMoveToZone {
     if (typeof countOrArgs === 'number') {
       return new ResolveMoveToZone(this.resolver, this.player, this.player.discard, { atLeast: countOrArgs, atMost: countOrArgs, like });
     }
     return new ResolveMoveToZone(this.resolver, this.player, this.player.discard, countOrArgs);
   }
 
-  public movesToHand(count: number, like?: Partial<Card>): ResolveMoveToZone;
+  public movesToHand(count: number, like?: FilterType): ResolveMoveToZone;
   public movesToHand({atLeast, atMost, like} : SelectCardArgs): ResolveMoveToZone;
-  public movesToHand(countOrArgs: number | SelectCardArgs, like?: Partial<Card>): ResolveMoveToZone {
+  public movesToHand(countOrArgs: number | SelectCardArgs, like?: FilterType): ResolveMoveToZone {
     if (typeof countOrArgs === 'number') {
       return new ResolveMoveToZone(this.resolver, this.player, this.player.hand, { atLeast: countOrArgs, atMost: countOrArgs, like });
     }
@@ -228,7 +226,7 @@ class ResolvePokemonCardList {
     public readonly pokemonRequirements: SelectPokemonArgs,
   ) {}
 
-  public andDiscards(count: number, like?: Partial<Card>): Generator<State, State>;
+  public andDiscards(count: number, like?: FilterType): Generator<State, State>;
   public andDiscards({atLeast, atMost, like} : SelectCardArgs): Generator<State, State>;
   public *andDiscards(countOrArgs: number | SelectCardArgs, like: FilterType = {}): Generator<State, State> {
     let atLeast: number | undefined;

--- a/packages/common/src/store/resolve-effect.ts
+++ b/packages/common/src/store/resolve-effect.ts
@@ -31,7 +31,7 @@ const ActionCanceled = {};
 
 // The most important function in this package.
 // It resolves the effect of a card, waiting for all prompts to resolve before moving the card to the appropriate zone.
-export function resolveEffect(store: StoreLike, state: State, effect: Effect, fail: (message: string) => void = throwCantPlay): State {
+export function resolveEffect(store: StoreLike, state: State, effect: Effect, fail: (message?: string) => void = throwCantPlay): State {
   if (effect instanceof TrainerEffect) {
     const source = effect.trainerCard;
     let generator: Generator<State, State> = function*(){throw new Error();}();
@@ -60,7 +60,7 @@ export function resolveEffect(store: StoreLike, state: State, effect: Effect, fa
   return state;
 }
 
-function throwCantPlay(message: string) {
+function throwCantPlay(message?: string) {
   throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
 }
 
@@ -71,7 +71,7 @@ export class Resolver {
     public readonly effectSource: Card,
     public readonly store: StoreLike,
     public readonly next: Function,
-    public readonly fail: (message: string) => void,
+    public readonly fail: (message?: string) => void,
   ) {
     this.require = new Require({
       activePlayer: this.state.players[0],

--- a/packages/common/src/store/resolve-effect.ts
+++ b/packages/common/src/store/resolve-effect.ts
@@ -1,0 +1,292 @@
+import { GameError } from '../game-error';
+import { GameMessage } from '../game-message';
+import { TrainerType } from './card/card-types';
+import { Effect } from './effects/effect';
+import { TrainerEffect } from './effects/play-card-effects';
+import { State } from './state/state';
+import { StoreLike } from './store-like';
+import { PlayerType, SlotType } from './actions/play-card-action';
+import { Card } from './card/card';
+import { ChooseCardsOptions, ChooseCardsPrompt, FilterType } from './prompts/choose-cards-prompt';
+import { ChoosePokemonOptions, ChoosePokemonPrompt } from './prompts/choose-pokemon-prompt';
+import { CoinFlipPrompt } from './prompts/coin-flip-prompt';
+import { ShuffleDeckPrompt } from './prompts/shuffle-prompt';
+import { Require } from './requirement';
+import { StateUtils } from './state-utils';
+import { CardList } from './state/card-list';
+import { Player } from './state/player';
+import { PokemonCardList } from './state/pokemon-card-list';
+import { getValidPokemonTargets, SelectPokemonArgs } from './target-utils';
+
+// SelectArgs defines the criteria for selecting cards from a zone.
+type SelectCardArgs = {atLeast?: number, atMost?: number, like?: FilterType}
+
+// PlayerEffect represents an effect that has a controller, such as TrainerEffect.
+type PlayerEffect = {
+  player: Player;
+}
+
+// A sentinel value that can be thrown to cancel an action.
+const ActionCanceled = {};
+
+// The most important function in this package.
+// It resolves the effect of a card, waiting for all prompts to resolve before moving the card to the appropriate zone.
+export function resolveEffect(store: StoreLike, state: State, effect: Effect, fail: (message: string) => void = throwCantPlay): State {
+  if (effect instanceof TrainerEffect) {
+    const source = effect.trainerCard;
+    let generator: Generator<State, State> = function*(){throw new Error();}();
+    const next = () => generator.next();
+    const act = new Resolver(effect, state, source, store, next, fail);
+    generator = function*() {
+      try {
+        yield* source.onPlay(act);
+      } catch (error) {
+        if (error === ActionCanceled) {
+          return state;
+        } else {
+          throw error;
+        }
+      }
+
+      if (effect.player.hand.cards.includes(effect.trainerCard)) {
+        const isSupporter = effect.trainerCard.trainerType === TrainerType.SUPPORTER;
+        const target = isSupporter ? effect.player.supporter : effect.player.discard;
+        effect.player.hand.moveCardTo(effect.trainerCard, target);
+      }
+      return state;
+    }();
+    return generator.next().value;
+  }
+  return state;
+}
+
+function throwCantPlay(message: string) {
+  throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
+}
+
+export class Resolver {
+  constructor(
+    public readonly effect: PlayerEffect,
+    public readonly state: State,
+    public readonly effectSource: Card,
+    public readonly store: StoreLike,
+    public readonly next: Function,
+    public readonly fail: (message: string) => void,
+  ) {
+    this.require = new Require({
+      activePlayer: this.state.players[0],
+      state: this.state,
+      effectSource: this.effectSource,
+      fail: fail,
+    });
+  }
+
+  // Track whether the operation has had any side effects that would prevent it from being rolled back,
+  // such as revealing hidden information, flipping coins, or moving cards.
+  public allowCancel = true;
+
+  public readonly require: Require;
+
+  private readonly excluded: Card[] = [this.effectSource];
+
+  public readonly player = new ResolveForPlayer(this, this.effect.player);
+  
+  public get opponent() {
+    return new ResolveForPlayer(this, StateUtils.getOpponent(this.state, this.effect.player));
+  }
+
+  public *choosesAndMoves(player: Player, from: CardList, to: CardList, message: GameMessage, query?: FilterType, args?: Partial<ChooseCardsOptions>): Generator<State, State> {
+    query = query || {};
+    const choices = from.filter(query).filter(card => !this.excluded.includes(card));
+    const min = args?.min || 1;
+    if (choices.length < min) {
+      throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
+    }
+
+    const choiceList = new CardList();
+    choiceList.cards = choices;
+
+    let chosenCards: Card[] = [];
+    yield this.store.prompt(
+      this.state,
+      new ChooseCardsPrompt(
+        player.id,
+        message,  
+        choiceList,
+        query,
+        { ...args, allowCancel: this.allowCancel },
+      ),
+      selected => {
+        chosenCards = selected || [];
+        this.allowCancel = false;
+        this.excluded.push(...chosenCards); // prevent choosing the same card again
+        this.next();
+      }
+    );
+
+    // Operation canceled by the user
+    if (chosenCards.length === 0) {
+      throw ActionCanceled;
+    }
+
+    from.moveCardsTo(chosenCards, to);
+    return this.state;
+  }
+}
+
+class ResolveForPlayer {
+  constructor(
+    public readonly act: Resolver,
+    public readonly player: Player,
+  ) {}
+
+  public draws(count: number): State {
+    this.player.deck.moveTo(this.player.hand, count);
+    return this.act.state;
+  }
+
+  public drawsUntil(count: number): State {
+    const cardsInHand = this.player.hand.cards.filter(card => card !== this.act.effectSource);
+    const cardsToDraw = Math.max(0, count - cardsInHand.length);
+    this.player.deck.moveTo(this.player.hand, cardsToDraw);
+    return this.act.state;
+  }
+
+  public discards(count: number, like?: Partial<Card>): ResolveMoveToZone;
+  public discards({atLeast, atMost, like} : SelectCardArgs): ResolveMoveToZone;
+  public discards(countOrArgs: number | SelectCardArgs, like?: Partial<Card>): ResolveMoveToZone {
+    if (typeof countOrArgs === 'number') {
+      return new ResolveMoveToZone(this.act, this.player, SlotType.DISCARD, this.player.discard, { atLeast: countOrArgs, atMost: countOrArgs, like });
+    }
+    return new ResolveMoveToZone(this.act, this.player, SlotType.DISCARD, this.player.discard, countOrArgs);
+  }
+
+  public movesToHand(count: number, like?: Partial<Card>): ResolveMoveToZone;
+  public movesToHand({atLeast, atMost, like} : SelectCardArgs): ResolveMoveToZone;
+  public movesToHand(countOrArgs: number | SelectCardArgs, like?: Partial<Card>): ResolveMoveToZone {
+    if (typeof countOrArgs === 'number') {
+      return new ResolveMoveToZone(this.act, this.player, SlotType.HAND, this.player.hand, { atLeast: countOrArgs, atMost: countOrArgs, like });
+    }
+    return new ResolveMoveToZone(this.act, this.player, SlotType.HAND, this.player.hand, countOrArgs);
+  }
+
+  public *flipsCoin(): Generator<State, boolean> {
+    let coinResult: boolean = false;
+    yield this.act.store.prompt(
+      this.act.state,
+      new CoinFlipPrompt(this.player.id, GameMessage.COIN_FLIP),
+      result => {
+        this.act.allowCancel = false;
+        coinResult = result;
+        this.act.next();
+      }
+    );
+    return coinResult;
+  }
+
+  public choosesPokemon(targetRequirement: SelectPokemonArgs, options: Partial<ChoosePokemonOptions> = {}) {
+    return new ResolvePokemonCardList(
+      this.act,
+      this.player,
+      targetRequirement
+    );
+  }
+}
+
+class ResolveMoveToZone {
+  constructor(
+    public readonly act: Resolver,
+    public readonly player: Player,
+    public readonly slotType: SlotType, 
+    public readonly to: CardList,
+    public readonly args: SelectCardArgs,
+  ) {}
+
+  public *fromHand(): Generator<State, State> {
+    const gameMessage = GameMessage.CHOOSE_CARD_TO_DISCARD;
+    return yield* this.act.choosesAndMoves(this.player, this.player.hand, this.to, gameMessage, this.args.like, {min: this.args.atLeast, max: this.args.atMost});
+  }
+
+  public *fromDeck(): Generator<State, State> {
+    const gameMessage = GameMessage.CHOOSE_CARD_TO_HAND;
+    const newState = yield* this.act.choosesAndMoves(this.player, this.player.deck, this.to, gameMessage, this.args.like, {min: this.args.atLeast, max: this.args.atMost});
+    return this.act.store.prompt(newState, new ShuffleDeckPrompt(this.player.id), order => {
+      this.player.deck.applyOrder(order);
+    });
+  }
+
+  public *fromDiscard(): Generator<State, State> {
+    const gameMessage = GameMessage.CHOOSE_CARD_TO_HAND;
+    return yield* this.act.choosesAndMoves(this.player, this.player.discard, this.to, gameMessage, this.args.like, {min: this.args.atLeast, max: this.args.atMost});
+  }
+}
+
+class ResolvePokemonCardList {
+  constructor(
+    public readonly act: Resolver,
+    public readonly player: Player,
+    public readonly pokemonRequirements: SelectPokemonArgs,
+  ) {}
+
+  public andDiscards(count: number, like?: Partial<Card>): Generator<State, State>;
+  public andDiscards({atLeast, atMost, like} : SelectCardArgs): Generator<State, State>;
+  public *andDiscards(countOrArgs: number | SelectCardArgs, like: FilterType = {}): Generator<State, State> {
+    let atLeast: number | undefined;
+    let atMost: number | undefined;
+    if (typeof countOrArgs === 'number') {
+      atLeast = countOrArgs;
+      atMost = countOrArgs;
+    } else {
+      ({ atLeast, atMost, like = {} } = countOrArgs);
+    }
+    const { blocked } = getValidPokemonTargets(this.act.state, this.player, this.pokemonRequirements);
+    let chosenPokemon: PokemonCardList[] = [];
+    yield this.act.store.prompt(
+      this.act.state,
+      new ChoosePokemonPrompt(
+        this.player.id,
+        GameMessage.CHOOSE_POKEMON_TO_DISCARD_CARDS,
+        this.pokemonRequirements.playerType || PlayerType.ANY,
+        this.pokemonRequirements.slots || [SlotType.ACTIVE, SlotType.BENCH],
+        { allowCancel: this.act.allowCancel, blocked }
+      ),
+      selected => {
+        this.act.allowCancel = false;
+        chosenPokemon = selected || [];
+        this.act.next();
+      }
+    );
+
+    if (chosenPokemon.length === 0) {
+      throw ActionCanceled;
+    }
+
+    const opponent = StateUtils.getOpponent(this.act.state, this.player);
+    let chosenPokemonController = opponent;
+    this.player.forEachPokemon(PlayerType.BOTTOM_PLAYER, (cardList, pokemonCard, target) => {
+      if(cardList === chosenPokemon[0]) {
+        chosenPokemonController = this.player;
+      }
+    });
+
+    let cards: Card[] = [];
+    yield this.act.store.prompt(
+      this.act.state,
+      new ChooseCardsPrompt(
+        this.player.id,
+        GameMessage.CHOOSE_CARD_TO_DISCARD,
+        chosenPokemon[0],
+        like,
+        { min: atLeast, max: atMost, allowCancel: false }
+      ),
+      selected => {
+        cards = selected;
+        this.act.next();
+      }
+    );
+
+    chosenPokemon[0].moveCardsTo(cards, chosenPokemonController.discard);
+    return this.act.state;
+  }
+}
+

--- a/packages/common/src/store/state/card-list.ts
+++ b/packages/common/src/store/state/card-list.ts
@@ -2,26 +2,28 @@ import { Card } from '../card/card';
 import { CardManager } from '../../game/cards/card-manager';
 import { GameError } from '../../game-error';
 import { GameMessage } from '../../game-message';
+import { match } from '../../utils';
 
 export class CardList {
 
-  public cards: Card[] = [];
+  public constructor(
+    public cards: Card[] = []
+  ) {}
 
   public isPublic: boolean = false;
 
   public isSecret: boolean = false;
 
   public static fromList(names: string[]): CardList {
-    const cardList = new CardList();
     const cardManager = CardManager.getInstance();
-    cardList.cards = names.map(cardName => {
+    const cards = names.map(cardName => {
       const card = cardManager.getCardByName(cardName);
       if (card === undefined) {
         throw new GameError(GameMessage.UNKNOWN_CARD, cardName);
       }
       return card;
     });
-    return cardList;
+    return new CardList(cards);
   }
 
   public applyOrder(order: number[]) {
@@ -74,18 +76,7 @@ export class CardList {
   }
 
   public filter(query: Partial<Card>): Card[] {
-    return this.cards.filter(c => {
-      for (const key in query) {
-        if (Object.prototype.hasOwnProperty.call(query, key)) {
-          const value: any = (c as any)[key];
-          const expected: any = (query as any)[key];
-          if (value !== expected) {
-            return false;
-          }
-        }
-      }
-      return true;
-    });
+    return this.cards.filter(c => match(c, query));
   }
 
   public count(query: Partial<Card>): number {

--- a/packages/common/src/store/state/card-list.ts
+++ b/packages/common/src/store/state/card-list.ts
@@ -2,7 +2,7 @@ import { Card } from '../card/card';
 import { CardManager } from '../../game/cards/card-manager';
 import { GameError } from '../../game-error';
 import { GameMessage } from '../../game-message';
-import { match } from '../../utils';
+import { Filter, match } from '../../utils';
 
 export class CardList {
 
@@ -75,11 +75,11 @@ export class CardList {
     return this.cards.slice(0, count);
   }
 
-  public filter(query: Partial<Card>): Card[] {
+  public filter(query: Filter<Card>): Card[] {
     return this.cards.filter(c => match(c, query));
   }
 
-  public count(query: Partial<Card>): number {
+  public count(query: Filter<Card>): number {
     return this.filter(query).length;
   }
 

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -27,6 +27,7 @@ import { playerStateReducer} from './reducers/player-state-reducer';
 import { retreatReducer } from './effect-reducers/retreat-effect';
 import { setupPhaseReducer } from './reducers/setup-reducer';
 import { abortGameReducer } from './reducers/abort-game-reducer';
+import { resolveEffect } from './resolve-effect';
 
 interface PromptItem {
   ids: number[],
@@ -89,6 +90,8 @@ export class Store implements StoreLike {
     if (effect.preventDefault === true) {
       return state;
     }
+
+    state = resolveEffect(this, state, effect);
 
     state = gamePhaseReducer(this, state, effect);
     state = playEnergyReducer(this, state, effect);

--- a/packages/common/src/store/target-utils.ts
+++ b/packages/common/src/store/target-utils.ts
@@ -13,7 +13,7 @@ export type SelectPokemonArgs = {
   playerType?: PlayerType;
   slots?: SlotType[];
   is?: Partial<PokemonCard>;
-  contains?: FilterType;
+  with?: FilterType;
 }
 
 export function getValidPokemonTargets(
@@ -23,7 +23,7 @@ export function getValidPokemonTargets(
     playerType = PlayerType.ANY,
     slots = [SlotType.ACTIVE, SlotType.BENCH],
     is = {},
-    contains = {},
+    with: with_ = {},
   }: SelectPokemonArgs,
 ): {
   matches: PokemonCardList[];
@@ -40,7 +40,7 @@ export function getValidPokemonTargets(
   const blocked: CardTarget[] = [];
   function check(candidate: PokemonCardList, player: Player, slot: SlotType, index: number) {
     const pokemon = candidate.getPokemonCard()!;
-    if (match(pokemon, is) && candidate.filter(contains).length > 0) {
+    if (match(pokemon, is) && candidate.filter(with_).length > 0) {
       matches.push(candidate);
     } else {
       blocked.push({player: player.id, slot, index });

--- a/packages/common/src/store/target-utils.ts
+++ b/packages/common/src/store/target-utils.ts
@@ -1,0 +1,64 @@
+import { match } from '../utils';
+import { CardTarget, PlayerType, SlotType } from './actions/play-card-action';
+import { PokemonCard } from './card/pokemon-card';
+import { FilterType } from './prompts/choose-cards-prompt';
+import { StateUtils } from './state-utils';
+import { Player } from './state/player';
+import { PokemonCardList } from './state/pokemon-card-list';
+import { State } from './state/state';
+
+export type SelectPokemonArgs = {
+  atLeast?: number;
+  atMost?: number;
+  playerType?: PlayerType;
+  slots?: SlotType[];
+  is?: Partial<PokemonCard>;
+  contains?: FilterType;
+}
+
+export function getValidPokemonTargets(
+  state: State,
+  player: Player,
+  {
+    playerType = PlayerType.ANY,
+    slots = [SlotType.ACTIVE, SlotType.BENCH],
+    is = {},
+    contains = {},
+  }: SelectPokemonArgs,
+): {
+  matches: PokemonCardList[];
+  blocked: CardTarget[];
+} {
+  const players = [];
+  if (playerType !== PlayerType.TOP_PLAYER) {
+    players.push(player);
+  }
+  if (playerType !== PlayerType.BOTTOM_PLAYER) {
+    players.push(StateUtils.getOpponent(state, player));
+  }
+  const matches: PokemonCardList[] = [];
+  const blocked: CardTarget[] = [];
+  function check(candidate: PokemonCardList, player: Player, slot: SlotType, index: number) {
+    const pokemon = candidate.getPokemonCard()!;
+    if (match(pokemon, is) && candidate.filter(contains).length > 0) {
+      matches.push(candidate);
+    } else {
+      blocked.push({player: player.id, slot, index });
+    }
+  }
+  for (const player of players) {
+    for (const slot of slots) {
+      if (slot === SlotType.ACTIVE) {
+        check(player.active, player, SlotType.ACTIVE, 0);
+      } else if (slot === SlotType.BENCH) {
+        for (let i = 0; i < player.bench.length; i++) {
+          const benchPokemon = player.bench[i];
+          check(benchPokemon, player, SlotType.BENCH, i);
+        }
+      } else {
+        throw new Error(`Invalid slot type for pokemon: ${slot}`);
+      }
+    }
+  }
+  return { matches, blocked };
+}

--- a/packages/common/src/test-utils.ts
+++ b/packages/common/src/test-utils.ts
@@ -3,7 +3,7 @@ import { GamePhase, Player, Prompt, Require, resolveEffect, ResolvePromptAction,
 import { Card } from './store/card/card';
 import { match } from './utils';
 
-function throwError(message: string): never {
+function throwError(message?: string): never {
   throw new Error(message);
 }
 

--- a/packages/common/src/test-utils.ts
+++ b/packages/common/src/test-utils.ts
@@ -81,9 +81,10 @@ class TestHarnessPlayer {
     return resolveEffect(this.harness.store, this.harness.state, effect, throwError);
   }
 
-  public getsPrompt({withText, withOptions} : {
+  public getsPrompt({withText, withOptions, withCards} : {
     withText?: GameMessage,
     withOptions?: any,
+    withCards?: Card[],
   }) {
     const prompts = this.harness.state.prompts;
     const prompt = prompts.find(p => p.result === undefined);
@@ -100,6 +101,14 @@ class TestHarnessPlayer {
     }
     if (prompt.playerId !== this.player.id) {
       throw new Error(`Expected prompt for player ${this.player.id} but found for player ${prompt.playerId}.`);
+    }
+    if (withCards !== undefined) {
+      const actualCards : Card[] = (prompt as any).cards.cards;
+      const choicesMatch = actualCards.length === withCards.length &&
+        actualCards.every((card, index) => card === withCards[index]);
+      if (!choicesMatch) {
+        throw new Error(`Expected prompt with choices matching ${JSON.stringify(withCards.map(v => v.fullName))} but found ${JSON.stringify(actualCards.map(v => v.fullName))}.`);
+      }
     }
     return new TestHarnessPrompt(this.harness, prompt);
   }

--- a/packages/common/src/test-utils.ts
+++ b/packages/common/src/test-utils.ts
@@ -1,0 +1,167 @@
+import { GameMessage } from './game-message';
+import { GamePhase, Player, Prompt, Require, resolveEffect, ResolvePromptAction, State, Store, SuperType, TrainerCard, TrainerEffect } from './store';
+import { Card } from './store/card/card';
+import { match } from './utils';
+
+function throwError(message: string): never {
+  throw new Error(message);
+}
+
+function makeTestCards(count: number): Card[] {
+  const cards: Card[] = Array(count);
+  for (let i = 0; i < count; i++) {
+    cards[i] = new TestCard(i);
+  }
+  return cards;
+}
+
+// A card with no types or abilities, used in tests.
+class TestCard extends Card {
+  constructor(
+    public id: any,
+  ) {
+    super();
+  }
+  
+  public set: string = 'TEST';
+  public superType: SuperType = SuperType.NONE;
+
+  get fullName(): string {
+    return `Test Card ${this.id}`;
+  }
+
+  get name(): string {
+    return `Test Card ${this.id}`;
+  }
+}
+
+const nullStoreHandler = {
+  onStateChange: (state: State) => {}
+};
+
+class TestHarness {
+  public store: Store;
+  public state: State;
+  public require: Require;
+  
+  constructor({
+    player = {},
+    opponent = {}
+  } : {player?: Partial<Player>, opponent?: Partial<Player>} = {}) {
+    this.store = new Store(nullStoreHandler);
+    this.state = this.store.state;
+    this.state.phase = GamePhase.PLAYER_TURN;
+    
+    const players = [Object.assign(new Player(), player), Object.assign(new Player(), opponent)];
+    if (players[0].id === players[1].id) {
+      players[1].id = players[0].id + 1; // Ensure different IDs
+    }
+    this.state.players = players;
+    
+    this.require = new Require({
+      activePlayer: this.state.players[0],
+      state: this.state,
+      fail: throwError,
+    });
+  }
+
+  public get players() {
+    return this.state.players.map(player => new TestHarnessPlayer(this, player));
+  }
+}
+
+class TestHarnessPlayer {
+  constructor(
+    private readonly harness: TestHarness,
+    public readonly player: Player
+  ) {}
+
+  public playsTrainer(card: TrainerCard): State {
+    const effect = new TrainerEffect(this.player, card);
+    return resolveEffect(this.harness.store, this.harness.state, effect, throwError);
+  }
+
+  public getsPrompt({withText, withOptions} : {
+    withText?: GameMessage,
+    withOptions?: any,
+  }) {
+    const prompts = this.harness.state.prompts;
+    const prompt = prompts.find(p => p.result === undefined);
+    if (prompt === undefined) {
+      throw new Error(`Expected prompt with message "${withText}" but no unresolved prompts were found.`);
+    }
+    const actualMessage = (prompt as any).message;
+    if (withText !== actualMessage) {
+      throw new Error(`Expected prompt with message "${withText}" but found "${actualMessage}".`);
+    }
+    const actualOptions = (prompt as any).options;
+    if (withOptions !== undefined && !match(actualOptions, withOptions)) {
+      throw new Error(`Expected prompt with options matching ${JSON.stringify(withOptions)} but found ${JSON.stringify(actualOptions)}.`);
+    }
+    if (prompt.playerId !== this.player.id) {
+      throw new Error(`Expected prompt for player ${this.player.id} but found for player ${prompt.playerId}.`);
+    }
+    return new TestHarnessPrompt(this.harness, prompt);
+  }
+
+  public flipsCoinAndGetsHeads() {
+    return this.flipsCoinAndGets(true);
+  }
+
+  public flipsCoinAndGetsTails() {
+    return this.flipsCoinAndGets(false);
+  }
+
+  private flipsCoinAndGets(heads: boolean): State {
+    const prompts = this.harness.state.prompts;
+    const prompt = prompts.find(p => p.result === undefined);
+    if (prompt === undefined) {
+      throw new Error('Expected coin flip prompt but no unresolved prompts were found.');
+    }
+    if (prompt.type !== 'Coin flip') {
+      throw new Error(`Expected coin flip prompt but found prompt of type "${prompt.type}".`);
+    }
+    const coinFlip = this.harness.store.dispatch(new ResolvePromptAction(prompt.id, heads));
+    if (coinFlip === undefined) {
+      throw new Error('Expected coin flip result but got undefined.');
+    }
+    return coinFlip;
+  }
+
+  // Asserts that there's a pending ShuffleDeck prompt and resolves it by reversing the order of the cards.
+  public shufflesDeck(): State {
+    const prompts = this.harness.state.prompts;
+    const prompt = prompts.find(p => p.result === undefined);
+    if (prompt === undefined) {
+      throw new Error('Expected shuffle deck prompt but no unresolved prompts were found.');
+    }
+    if (prompt.type !== 'Shuffle deck') {
+      throw new Error(`Expected shuffle deck prompt but found prompt of type "${prompt.type}".`);
+    }
+
+    const deckSize = this.player.deck.cards.length;
+    const shuffleResult = Array.from({ length: deckSize }, (_, i) => deckSize-i-1);
+    const coinFlip = this.harness.store.dispatch(new ResolvePromptAction(prompt.id, shuffleResult));
+    if (coinFlip === undefined) {
+      throw new Error('Expected coin flip result but got undefined.');
+    }
+    return coinFlip;
+  }
+}
+
+class TestHarnessPrompt<T> {
+  constructor(
+    private readonly harness: TestHarness,
+    private readonly prompt: Prompt<T>,
+  ) {}
+
+  public andChooses(choice: T): State {
+    return this.harness.store.dispatch(new ResolvePromptAction(this.prompt.id, choice));
+  }
+}
+
+export const TestUtils = {
+  TestCard,
+  TestHarness,
+  makeTestCards,
+};

--- a/packages/common/src/utils/utils.ts
+++ b/packages/common/src/utils/utils.ts
@@ -97,3 +97,16 @@ export function generateId<T extends {id: number}[]>(array: T): number {
 
   return id;
 }
+
+export function match<T>(self: T, query: Partial<T>): boolean {
+  for (const key in query) {
+    if (Object.prototype.hasOwnProperty.call(query, key)) {
+      const value: any = (self as any)[key];
+      const expected: any = (query as any)[key];
+      if (!deepCompare(value, expected)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/packages/common/src/utils/utils.ts
+++ b/packages/common/src/utils/utils.ts
@@ -98,13 +98,23 @@ export function generateId<T extends {id: number}[]>(array: T): number {
   return id;
 }
 
-export function match<T>(self: T, query: Partial<T>): boolean {
+export type Filter<T> = {
+  [K in keyof T]?: T[K] | ((value: T[K]) => boolean);
+};
+
+export function match<T>(self: T, query: Filter<T>): boolean {
   for (const key in query) {
     if (Object.prototype.hasOwnProperty.call(query, key)) {
       const value: any = (self as any)[key];
       const expected: any = (query as any)[key];
-      if (!deepCompare(value, expected)) {
-        return false;
+      if (typeof expected === 'function') {
+        if (!expected(value)) {
+          return false;
+        }
+      } else {
+        if (!deepCompare(value, expected)) {
+          return false;
+        }
       }
     }
   }

--- a/packages/play/src/app/table/prompt/prompt-choose-cards/prompt-choose-cards.component.ts
+++ b/packages/play/src/app/table/prompt/prompt-choose-cards/prompt-choose-cards.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { ChooseCardsPrompt, CardList, Card } from '@ptcg/common';
+import { ChooseCardsPrompt, CardList, Card, Filter } from '@ptcg/common';
 
 import { GameService } from '../../../api/services/game.service';
 import { LocalGameState } from '../../../shared/session/session.interface';
@@ -34,7 +34,7 @@ export class PromptChooseCardsComponent {
   public allowedCancel: boolean;
   public promptId: number;
   public message: string;
-  public filter: Partial<Card>;
+  public filter: Filter<Card>;
   public blocked: number[];
   public isInvalid = false;
   public isSecret: boolean;

--- a/packages/sets/package.json
+++ b/packages/sets/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint -c .eslintrc.js --ext .ts src",
     "compile": "tsc && tsc -p tsconfig.esm.json",
     "build": "npm run lint && npm run test && npm run compile",
-    "test": "echo \"Info: no tests specified for this package\"",
+    "test": "jasmine-ts \"src/**/*.spec.ts\"",
     "coverage": "npm test"
   },
   "author": "",

--- a/packages/sets/src/standard/set-black-and-white/bianca.ts
+++ b/packages/sets/src/standard/set-black-and-white/bianca.ts
@@ -1,12 +1,8 @@
 import {
-  Effect,
-  GameError,
-  GameMessage,
   State,
-  StoreLike,
   TrainerCard,
-  TrainerEffect,
   TrainerType,
+  Resolver,
 } from '@ptcg/common';
 
 export class Bianca extends TrainerCard {
@@ -20,19 +16,9 @@ export class Bianca extends TrainerCard {
 
   public text: string = 'Draw cards until you have 6 cards in your hand.';
 
-  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    if (effect instanceof TrainerEffect && effect.trainerCard === this) {
-      const player = effect.player;
-      const cards = player.hand.cards.filter(c => c !== this);
-      const cardsToDraw = Math.max(0, 6 - cards.length);
-
-      if (cardsToDraw === 0 || player.deck.cards.length === 0) {
-        throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
-      }
-
-      player.deck.moveTo(player.hand, cardsToDraw);
-    }
-
-    return state;
+  override *onPlay({require, player}: Resolver): Generator<State> {
+    require.player.deck.isNotEmpty();
+    require.player.hand.contains({atMost: 5});
+    player.drawsUntil(6);
   }
 }

--- a/packages/sets/src/standard/set-black-and-white/black-and-white.spec.ts
+++ b/packages/sets/src/standard/set-black-and-white/black-and-white.spec.ts
@@ -1,0 +1,220 @@
+/*
+For each card test:
+1. Describe the game state before the action is taken.
+2. Describe the action, any prompts we expect, and how the player responds.
+3. Describe expectations after the action completes.
+*/
+
+import { Card, CardList, EnergyCard, GameMessage, PokemonCard, PokemonCardList, SlotType } from '@ptcg/common';
+import { Bianca } from './bianca';
+import { ComputerSearch } from './computer-search';
+import { TestUtils } from '@ptcg/common';
+import { CrushingHammer } from './crushing-hammer';
+import { Emolga } from './emolga';
+import { WaterEnergy } from '../set-diamond-and-pearl/water-energy';
+
+describe('Bianca', () => {
+
+  it('draws until you have 6 cards in hand', () => {
+    const bianca = new Bianca();
+    const hand: CardList = new CardList([bianca]);
+    const deck: CardList = new CardList(TestUtils.makeTestCards(6));
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { require, players: [player] } = harness;
+    player.playsTrainer(bianca);
+    require.player.hand.contains(6);
+    require.player.deck.isEmpty();
+    require.player.supporter.contains([bianca]);
+  });
+
+  it('can\'t be played if the user already has 6 other cards', () => {
+    const bianca = new Bianca();
+    const hand: CardList = new CardList([bianca, ...TestUtils.makeTestCards(6)]);
+    const deck: CardList = new CardList(TestUtils.makeTestCards(6));
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { players: [player] } = harness;
+    expect(
+      () => player.playsTrainer(bianca)
+    ).toThrowError(
+      'player\'s hand contains too many cards matching the criteria. Expected at most 5, found 6.');
+  });
+
+  it('can\'t be played if the user has no cards in deck', () => {
+    const bianca = new Bianca();
+    const hand: CardList = new CardList([bianca]);
+    const deck: CardList = new CardList([]);
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { players: [player] } = harness;
+    expect(
+      () => player.playsTrainer(bianca)
+    ).toThrowError(
+      'player\'s deck unexpectedly empty.');
+  });
+
+  it('if the user doesn\'t have enough cards in deck, draw all of them', () => {
+    const bianca = new Bianca();
+    const hand: CardList = new CardList([bianca, ...TestUtils.makeTestCards(1)]);
+    const deck: CardList = new CardList(TestUtils.makeTestCards(2));
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { require, players: [player] } = harness;
+    player.playsTrainer(bianca);
+    require.player.hand.contains(3);
+    require.player.deck.isEmpty();
+    require.player.supporter.contains([bianca]);
+  });
+});
+
+
+describe('Computer Search', () => {
+
+  it('has basic functionality', () => {
+    const computerSearch = new ComputerSearch();
+    const hand1: Card = new TestUtils.TestCard('Hand1');
+    const hand2: Card = new TestUtils.TestCard('Hand2');
+    const deckCards: Card[] = TestUtils.makeTestCards(5);
+    const [searchTarget, ...remainingDeckCards] = deckCards;
+    const hand: CardList = new CardList([computerSearch, hand1, hand2]);
+    const deck: CardList = new CardList(deckCards);
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { require, players: [player] } = harness;
+    
+    
+    player.playsTrainer(computerSearch);
+    // We haven't finished resolving computerSearch yet, so the card shouldn't be in the discard pile.
+    require.player.discard.doesNotContain(computerSearch);
+    player.getsPrompt({
+      withText: GameMessage.CHOOSE_CARD_TO_DISCARD,
+      withOptions: { min: 2, max: 2, allowCancel: true }
+    }).andChooses([hand1, hand2]);
+    player.getsPrompt({
+      withText: GameMessage.CHOOSE_CARD_TO_HAND,
+      withOptions: { min: 1, max: 1, allowCancel: false }}
+    ).andChooses([searchTarget]);
+    player.shufflesDeck();
+    require.player.hand.contains([searchTarget]);
+    require.player.discard.contains([hand1, hand2, computerSearch]);
+
+    // Test that the deck was shuffled. It should contain the remaining cards, but not in reversed order.
+    require.player.deck.isInOrder(remainingDeckCards.reverse());
+  });
+
+  it('can be cancelled', () => {
+    const computerSearch = new ComputerSearch();
+    const hand1: Card = new TestUtils.TestCard('Hand1');
+    const hand2: Card = new TestUtils.TestCard('Hand2');
+    const deck1: Card = new TestUtils.TestCard('Deck1');
+    const hand: CardList = new CardList([computerSearch, hand1, hand2]);
+    const deck: CardList = new CardList([deck1]);
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { require, players: [player] } = harness;
+    
+    player.playsTrainer(computerSearch);
+    player.getsPrompt({
+      withText: GameMessage.CHOOSE_CARD_TO_DISCARD,
+      withOptions: { min: 2, max: 2, allowCancel: true }
+    }).andChooses([]);
+
+    // The player cancelled the prompt, so no cards should be discarded or added to hand.
+    require.noPrompts();
+    require.player.hand.contains([computerSearch, hand1, hand2]);
+  });
+
+  it('without enough cards to discard', () => {
+    const computerSearch = new ComputerSearch();
+    const hand1: Card = new TestUtils.TestCard('Hand1');
+    const deck1: Card = new TestUtils.TestCard('Deck1');
+    const hand: CardList = new CardList([computerSearch, hand1]);
+    const deck: CardList = new CardList([deck1]);
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { players: [player] } = harness;
+    
+    expect(
+      () => player.playsTrainer(computerSearch)
+    ).toThrowError(
+      'player\'s hand does not contain enough cards matching the criteria. Expected at least 2, found 1.');
+  });
+
+  it('without a valid card to search for', () => {
+    const computerSearch = new ComputerSearch();
+    const hand1: Card = new TestUtils.TestCard('Hand1');
+    const hand2: Card = new TestUtils.TestCard('Hand2');
+    const hand: CardList = new CardList([computerSearch, hand1, hand2]);
+    const deck: CardList = new CardList([]);
+    const harness = new TestUtils.TestHarness({player: { hand, deck }});
+    const { players: [player] } = harness;
+    
+    expect(
+      () => player.playsTrainer(computerSearch)
+    ).toThrowError(
+      'player\'s deck unexpectedly empty.');
+  });
+});
+
+describe('Crushing Hammer', () => {
+  it('has basic functionality: heads', () => {
+    const crushingHammer = new CrushingHammer();
+
+    const activePokemon: PokemonCard = new Emolga();
+    const activePokemonEnergy: EnergyCard = new WaterEnergy();
+    const activePokemonList = new PokemonCardList([activePokemon, activePokemonEnergy]);
+
+    const benchPokemonWithEnergy: PokemonCard = new Emolga();
+    const benchPokemonEnergy = new WaterEnergy();
+    const benchPokemonWithEnergyList = new PokemonCardList([benchPokemonWithEnergy, benchPokemonEnergy]);
+
+    const benchPokemonWithoutEnergy = new Emolga();
+    const benchPokemonWithoutEnergyList = new PokemonCardList([benchPokemonWithoutEnergy]);
+
+    const board = {
+      player: { hand: new CardList([crushingHammer]) },
+      opponent: { 
+        active: activePokemonList,
+        bench: [
+          benchPokemonWithEnergyList,
+          benchPokemonWithoutEnergyList,
+        ]
+      }};
+    const harness = new TestUtils.TestHarness(board);
+    const { require, players: [player] } = harness;
+    
+    player.playsTrainer(crushingHammer);
+    // We haven't finished resolving computerSearch yet, so the card shouldn't be in the discard pile.
+    require.player.discard.doesNotContain(crushingHammer);
+
+    player.flipsCoinAndGetsHeads();
+    player.getsPrompt({
+      withText: GameMessage.CHOOSE_POKEMON_TO_DISCARD_CARDS,
+      withOptions: {
+        min: 1,
+        max: 1,
+        allowCancel: false,
+        blocked: [{player: 1, slot: SlotType.BENCH, index: 1}]
+      },
+    }).andChooses([activePokemonList]);
+    player.getsPrompt({
+      withText: GameMessage.CHOOSE_CARD_TO_DISCARD,
+      withOptions: { allowCancel: false },
+    }).andChooses([activePokemonEnergy]);
+    require.opponent.activeSpot.contains([activePokemon]);
+    require.opponent.activeSpot.doesNotContain(activePokemonEnergy);
+    require.opponent.discard.contains([activePokemonEnergy]);
+  });
+
+  it('has basic functionality: tails', () => {
+    const crushingHammer = new CrushingHammer();
+    const targetPokemon: PokemonCard = new Emolga();
+    const energy: EnergyCard = new WaterEnergy();
+    const active: PokemonCardList = new PokemonCardList([targetPokemon, energy]);
+    const hand: CardList = new CardList([crushingHammer]);
+    const harness = new TestUtils.TestHarness({player: { hand }, opponent: { active }});
+    const { require, players: [player] } = harness;
+    
+    player.playsTrainer(crushingHammer);
+    // We haven't finished resolving computerSearch yet, so the card shouldn't be in the discard pile.
+    require.player.discard.doesNotContain(crushingHammer);
+
+    player.flipsCoinAndGetsTails();
+    require.noPrompts();
+    require.player.discard.contains([crushingHammer]);
+  });
+});

--- a/packages/sets/src/standard/set-black-and-white/cheren.ts
+++ b/packages/sets/src/standard/set-black-and-white/cheren.ts
@@ -1,13 +1,8 @@
 import {
-  Effect,
-  GameError,
-  GameMessage,
   State,
-  StoreLike,
   TrainerCard,
-  TrainerEffect,
   TrainerType,
-} from '@ptcg/common';
+  Resolver } from '@ptcg/common';
 
 export class Cheren extends TrainerCard {
   public trainerType: TrainerType = TrainerType.SUPPORTER;
@@ -20,17 +15,8 @@ export class Cheren extends TrainerCard {
 
   public text: string = 'Draw 3 cards.';
 
-  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    if (effect instanceof TrainerEffect && effect.trainerCard === this) {
-      const player = effect.player;
-
-      if (player.deck.cards.length === 0) {
-        throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
-      }
-
-      player.deck.moveTo(player.hand, 3);
-    }
-
-    return state;
+  override *onPlay({require, player}: Resolver): Generator<State> {
+    require.player.deck.isNotEmpty();
+    player.draws(3);
   }
 }

--- a/packages/sets/src/standard/set-black-and-white/colress.ts
+++ b/packages/sets/src/standard/set-black-and-white/colress.ts
@@ -2,6 +2,7 @@ import {
   Effect,
   GameError,
   GameMessage,
+  Resolver,
   ShuffleDeckPrompt,
   State,
   StateUtils,
@@ -23,6 +24,19 @@ export class Colress extends TrainerCard {
   public text: string =
     'Shuffle your hand into your deck. Then, draw a number of cards equal ' +
     'to the number of Benched Pokémon (both yours and your opponent\'s).';
+
+  override *onPlay({ require, player, state }: Resolver): Generator<State> {
+    require.check(
+      (player.player.hand.cards.length > 0) ||
+      (player.player.deck.cards.length > 0),
+    );
+    let benchCount = 0;
+    for (const player of state.players) {
+      player.bench.forEach(b => (benchCount += b.cards.length > 0 ? 1 : 0));
+    }
+    player.shufflesHandIntoDeck();
+    return player.draws(benchCount);
+  }
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof TrainerEffect && effect.trainerCard === this) {

--- a/packages/sets/src/standard/set-black-and-white/crushing-hammer.ts
+++ b/packages/sets/src/standard/set-black-and-white/crushing-hammer.ts
@@ -1,92 +1,10 @@
 import {
-  Card,
-  CardTarget,
-  ChooseCardsPrompt,
-  ChoosePokemonPrompt,
-  CoinFlipPrompt,
-  Effect,
-  GameError,
-  GameMessage,
+  Resolver,
   PlayerType,
-  PokemonCardList,
-  SlotType,
-  State,
-  StateUtils,
-  StoreLike,
   SuperType,
   TrainerCard,
-  TrainerEffect,
   TrainerType,
 } from '@ptcg/common';
-
-function* playCard(next: Function, store: StoreLike, state: State, effect: TrainerEffect): IterableIterator<State> {
-  const player = effect.player;
-  const opponent = StateUtils.getOpponent(state, player);
-
-  let hasPokemonWithEnergy = false;
-  const blocked: CardTarget[] = [];
-  opponent.forEachPokemon(PlayerType.TOP_PLAYER, (cardList, card, target) => {
-    if (cardList.cards.some(c => c.superType === SuperType.ENERGY)) {
-      hasPokemonWithEnergy = true;
-    } else {
-      blocked.push(target);
-    }
-  });
-
-  if (!hasPokemonWithEnergy) {
-    throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
-  }
-
-  let coinResult: boolean = false;
-  yield store.prompt(state, new CoinFlipPrompt(player.id, GameMessage.COIN_FLIP), result => {
-    coinResult = result;
-    next();
-  });
-
-  if (coinResult === false) {
-    return state;
-  }
-
-  let targets: PokemonCardList[] = [];
-  yield store.prompt(
-    state,
-    new ChoosePokemonPrompt(
-      player.id,
-      GameMessage.CHOOSE_POKEMON_TO_DISCARD_CARDS,
-      PlayerType.TOP_PLAYER,
-      [SlotType.ACTIVE, SlotType.BENCH],
-      { allowCancel: false, blocked }
-    ),
-    results => {
-      targets = results || [];
-      next();
-    }
-  );
-
-  if (targets.length === 0) {
-    return state;
-  }
-
-  const target = targets[0];
-  let cards: Card[] = [];
-  yield store.prompt(
-    state,
-    new ChooseCardsPrompt(
-      player.id,
-      GameMessage.CHOOSE_CARD_TO_DISCARD,
-      target,
-      { superType: SuperType.ENERGY },
-      { min: 1, max: 1, allowCancel: false }
-    ),
-    selected => {
-      cards = selected;
-      next();
-    }
-  );
-
-  target.moveCardsTo(cards, opponent.discard);
-  return state;
-}
 
 export class CrushingHammer extends TrainerCard {
   public trainerType: TrainerType = TrainerType.ITEM;
@@ -99,11 +17,16 @@ export class CrushingHammer extends TrainerCard {
 
   public text: string = 'Flip a coin. If heads, discard an Energy attached to 1 of your opponent\'s Pokémon.';
 
-  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    if (effect instanceof TrainerEffect && effect.trainerCard === this) {
-      const generator = playCard(() => generator.next(), store, state, effect);
-      return generator.next().value;
+  override *onPlay({ require, player }: Resolver) {
+    require.opponent.hasPokemon({with: {superType: SuperType.ENERGY}});
+    const isHeads = yield* player.flipsCoin();
+    if (isHeads) {
+      yield* player.choosesPokemon({
+        playerType: PlayerType.TOP_PLAYER,
+        with: {superType: SuperType.ENERGY},
+      }).andDiscards({
+        like: { superType: SuperType.ENERGY },
+      });
     }
-    return state;
   }
 }

--- a/packages/sets/src/standard/set-black-and-white/dowsing-machine.ts
+++ b/packages/sets/src/standard/set-black-and-white/dowsing-machine.ts
@@ -1,98 +1,11 @@
 import {
-  Card,
-  CardList,
+  Resolver,
   CardTag,
-  ChooseCardsPrompt,
-  Effect,
-  GameError,
-  GameMessage,
   State,
-  StoreLike,
   SuperType,
   TrainerCard,
-  TrainerEffect,
   TrainerType,
 } from '@ptcg/common';
-
-function* playCard(
-  next: Function,
-  store: StoreLike,
-  state: State,
-  self: DowsingMachine,
-  effect: TrainerEffect
-): IterableIterator<State> {
-  const player = effect.player;
-  let cards: Card[] = [];
-
-  cards = player.hand.cards.filter(c => c !== self);
-  if (cards.length < 2) {
-    throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
-  }
-
-  let trainersInDiscard = 0;
-  player.discard.cards.forEach(c => {
-    if (c instanceof TrainerCard) {
-      trainersInDiscard += 1;
-    }
-  });
-  if (trainersInDiscard === 0) {
-    throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
-  }
-
-  // We will discard this card after prompt confirmation
-  effect.preventDefault = true;
-
-  // prepare card list without Junk Arm
-  const handTemp = new CardList();
-  handTemp.cards = player.hand.cards.filter(c => c !== self);
-
-  cards = [];
-  yield store.prompt(
-    state,
-    new ChooseCardsPrompt(
-      player.id,
-      GameMessage.CHOOSE_CARD_TO_DISCARD,
-      handTemp,
-      {},
-      { min: 2, max: 2, allowCancel: true }
-    ),
-    selected => {
-      cards = selected || [];
-      next();
-    }
-  );
-
-  // Operation canceled by the user
-  if (cards.length === 0) {
-    return state;
-  }
-
-  let recovered: Card[] = [];
-  yield store.prompt(
-    state,
-    new ChooseCardsPrompt(
-      player.id,
-      GameMessage.CHOOSE_CARD_TO_HAND,
-      player.discard,
-      { superType: SuperType.TRAINER },
-      { min: 1, max: 1, allowCancel: true }
-    ),
-    selected => {
-      recovered = selected || [];
-      next();
-    }
-  );
-
-  // Operation cancelled by the user
-  if (recovered.length === 0) {
-    return state;
-  }
-
-  player.hand.moveCardTo(self, player.discard);
-  player.hand.moveCardsTo(cards, player.discard);
-  player.discard.moveCardsTo(recovered, player.hand);
-  return state;
-}
 
 export class DowsingMachine extends TrainerCard {
   public trainerType: TrainerType = TrainerType.ITEM;
@@ -110,11 +23,10 @@ export class DowsingMachine extends TrainerCard {
     'you can\'t play this card.) Put a Trainer card from your discard ' +
     'pile into your hand.';
 
-  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    if (effect instanceof TrainerEffect && effect.trainerCard === this) {
-      const generator = playCard(() => generator.next(), store, state, this, effect);
-      return generator.next().value;
-    }
-    return state;
+  override *onPlay({require, player}: Resolver): Generator<State> {
+    require.player.hand.contains({atLeast: 2});
+    require.player.discard.contains({like: {superType: SuperType.TRAINER}});
+    yield* player.discards(2).fromHand();
+    yield* player.movesToHand(1, {superType: SuperType.TRAINER}).fromDiscard();
   }
 }

--- a/packages/sets/src/standard/set-black-and-white/energy-retrieval.ts
+++ b/packages/sets/src/standard/set-black-and-white/energy-retrieval.ts
@@ -1,56 +1,10 @@
 import {
-  ChooseCardsPrompt,
-  Effect,
-  EnergyCard,
-  EnergyType,
-  GameError,
-  GameMessage,
+  FilterType,
+  Resolver,
   State,
-  StoreLike,
-  SuperType,
   TrainerCard,
-  TrainerEffect,
   TrainerType,
 } from '@ptcg/common';
-
-function* playCard(next: Function, store: StoreLike, state: State, effect: TrainerEffect): IterableIterator<State> {
-  const player = effect.player;
-
-  // Player has no Basic Energy in the discard pile
-  let basicEnergyCards = 0;
-  player.discard.cards.forEach(c => {
-    if (c instanceof EnergyCard && c.energyType === EnergyType.BASIC) {
-      basicEnergyCards++;
-    }
-  });
-  if (basicEnergyCards === 0) {
-    throw new GameError(GameMessage.CANNOT_PLAY_THIS_CARD);
-  }
-
-  // We will discard this card after prompt confirmation
-  effect.preventDefault = true;
-
-  const min = Math.min(basicEnergyCards, 2);
-  return store.prompt(
-    state,
-    new ChooseCardsPrompt(
-      player.id,
-      GameMessage.CHOOSE_CARD_TO_HAND,
-      player.discard,
-      { superType: SuperType.ENERGY, energyType: EnergyType.BASIC },
-      { min, max: min, allowCancel: true }
-    ),
-    cards => {
-      cards = cards || [];
-      if (cards.length > 0) {
-        // Discard trainer only when user selected a Pokemon
-        player.hand.moveCardTo(effect.trainerCard, player.discard);
-        // Recover discarded Pokemon
-        player.discard.moveCardsTo(cards, player.hand);
-      }
-    }
-  );
-}
 
 export class EnergyRetrieval extends TrainerCard {
   public trainerType: TrainerType = TrainerType.ITEM;
@@ -63,12 +17,9 @@ export class EnergyRetrieval extends TrainerCard {
 
   public text: string = 'Put 2 basic Energy cards from your discard pile into your hand.';
 
-  public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    if (effect instanceof TrainerEffect && effect.trainerCard === this) {
-      const generator = playCard(() => generator.next(), store, state, effect);
-      return generator.next().value;
-    }
-
-    return state;
+  override *onPlay({ require, player }: Resolver): Generator<State> {
+    // const basicEnergy = { superType: SuperType.ENERGY, energyType: EnergyType.BASIC };
+    require.player.discard.contains({like: FilterType.BASIC_ENERGY});
+    yield* player.movesToHand(2, FilterType.BASIC_ENERGY).fromDiscard();
   }
 }

--- a/packages/sets/src/standard/set-black-and-white/enhanced-hammer.ts
+++ b/packages/sets/src/standard/set-black-and-white/enhanced-hammer.ts
@@ -6,10 +6,12 @@ import {
   Effect,
   EnergyCard,
   EnergyType,
+  FilterType,
   GameError,
   GameMessage,
   PlayerType,
   PokemonCardList,
+  Resolver,
   SlotType,
   State,
   StateUtils,
@@ -98,6 +100,18 @@ export class EnhancedHammer extends TrainerCard {
   public fullName: string = 'Enhanced Hammer DEX';
 
   public text: string = 'Discard a Special Energy attached to 1 of your opponent\'s Pokémon.';
+
+  override *onPlay({ require, player, store, state }: Resolver): Generator<State> {
+    require.opponent.hasPokemon({
+      with: FilterType.SPECIAL_ENERGY,
+    });
+    yield* player.choosesPokemon({
+      playerType: PlayerType.TOP_PLAYER,
+      with: FilterType.SPECIAL_ENERGY,
+    }).andDiscards({
+      like: FilterType.SPECIAL_ENERGY,
+    });
+  }
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof TrainerEffect && effect.trainerCard === this) {


### PR DESCRIPTION
(Don't feel pressured to merge this PR unless you're confident and comfortable with it; I've just been playing around and wanted to make you aware of what I've been working on.)

The way that card effects is currently implemented has some shortcomings:
- Card effects are difficult and cumbersome to implement
- Cards with similar effects have a large amount of code duplication
- Fixing a bug or changing the Store interface may require refactoring a large number of card implementations
- Test coverage of cards is nearly impossible

We can fix all of these issues by creating a library of components that can be combined in order to implement cards. This PR is a proof of concept for this approach, showcasing a small number of components and using them to implement a few trainer cards through an additional `onPlay` method. This approach coexists alongside cards that implement their effect inside `reduceEffect`, allowing for cards to be gradually migrated, or for cards to fall back on using `reduceEffect` if they really need to.

This has the following benefits:

## 1: Card effects become easier to read and faster to write

Here's what a simple trainer effect looks like using this design: Cheren's "Draw 3 cards":

```ts
  override *onPlay({require, player}: Resolver): Generator<State> {
    require.player.deck.isNotEmpty();
    player.draws(3);
  }
  ```

And a more complicated example, implementing Crushing Hammer's "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon":

```ts
  override *onPlay({ require, player }: Resolver) {
    require.opponent.hasPokemon({with: {superType: SuperType.ENERGY}});
    const isHeads = yield* player.flipsCoin();
    if (isHeads) {
      yield* player.choosesPokemon({
        playerType: PlayerType.TOP_PLAYER,
        with: {superType: SuperType.ENERGY},
      }).andDiscards({
        like: { superType: SuperType.ENERGY },
      });
    }
  }
```

## 2: We can automatically handle common patterns and prevent easy mistakes

This library has logic built-in for intelligently:
- Preventing players from discarding a trainer card to it's own effect / retrieving cards from the discard that were put there while resolving the trainer card.
- Determining whether a prompt can be cancelled
- Putting the trainer card in the discard at the correct time (after all prompts are resolved)
- Shuffling the deck whenever it's searched.

With the existing approach, every card needs to explicitly consider these cases, which makes it easy to accidentally include bugs.

This isn't hypothetical: the current implementation of Computer Search was updated *this week* to fix a bug that caused it to not shuffle the deck after use.

## 3: We can write tests for card abilities

We don't need to write a test for every card. But when we add a new component, we can write tests that provide it with coverage, by simulating actual cards that use that component.

To demonstrate this, I wrote a test harness for setting up a board state, dispatching specific actions, and then validating the resulting state. The goal is to allow writing tests with a similar "fluent" style and syntax to the card effects themselves. Check out "black-and-white.spec.ts" for some examples.

## Future Work

Currently only trainer cards are supported. Next steps would be:
- Adding similar support to energy, attacks, and activated abilities / poke-powers
- Designing a similar library of composable pieces for expressing static abilities / poke-bodies
